### PR TITLE
Fixes some tests and adds premature Python3-support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
+sudo: false
 python:
     - "2.7"
+    - "3.4"
 install:
     - ./travis-build.sh
     - pip install coveralls

--- a/snapshotter/snapshotter.py
+++ b/snapshotter/snapshotter.py
@@ -4,6 +4,8 @@
 See README.markdown for instructions.
 
 """
+from __future__ import unicode_literals
+
 import datetime
 import sys
 import os
@@ -11,6 +13,12 @@ import subprocess
 import argparse
 import re
 import logging
+
+
+if sys.version_info[0] == 2:
+    PY2, PY3 = True, False
+elif sys.version_info[0] == 3:
+    PY2, PY3 = False, True
 
 
 def _info(message):
@@ -22,8 +30,11 @@ class CalledProcessError(Exception):
     """Exception type that's raised if an external command fails."""
 
     def __init__(self, command, output, exit_value):
-        super(CalledProcessError, self).__init__(
-            output + " " + str(exit_value))
+        if PY2:
+            output = unicode(output) + " " + unicode(exit_value)  # noqa
+        elif PY3:
+            output = str(output) + " " + str(exit_value)
+        super(CalledProcessError, self).__init__(output)
         self.command = command
         self.output = output
         self.exit_value = exit_value
@@ -124,7 +135,7 @@ def _rsync(source, dest, debug=False, extra_args=None):
         _run(rsync_cmd)
     except CalledProcessError as err:
         if err.exit_value == 11 and "No space left on device" in err.output:
-            raise NoSpaceLeftOnDeviceError(err.message)
+            raise NoSpaceLeftOnDeviceError(err.output)
         else:
             raise
 

--- a/snapshotter/test_snapshotter.py
+++ b/snapshotter/test_snapshotter.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import os
 import tempfile
 import sys
@@ -6,7 +8,10 @@ import shutil
 import mock
 import nose.tools
 
-import snapshotter
+from . import snapshotter
+
+
+PY2, PY3 = snapshotter.PY2, snapshotter.PY3
 
 
 def _this_directory():
@@ -29,7 +34,11 @@ class TestRun(object):
             assert False, "We shouldn't get here"
         except snapshotter.CalledProcessError as err:
             assert err.command == command
-            assert err.output.startswith("rsync: --foobar: unknown option")
+            # FIXME remove debug statements when fixed
+            print("type(err.output): %s" % type(err.output))
+            print("err.output: %s" % err.output)
+            #err.output = err.output.encode()
+            assert err.output.encode().startswith("rsync: --foobar: unknown option")
             assert err.exit_value == 1
 
     def test_command_does_not_exist(self):
@@ -251,7 +260,7 @@ class TestSnapshot(object):
             snapshotter.snapshot(src, dst, debug=True)
             assert False, "snapshot() should have raised an exception"
         except snapshotter.CalledProcessError as err:
-            assert err.message == "output 11"
+            assert err.output == "output 11"
 
     def test_link_dest(self):
         """The right --link-dest=... arg should be given to rsync."""
@@ -415,7 +424,7 @@ class TestSnapshot(object):
             snapshotter.snapshot(src, dst)
             assert False, "snapshot() should have raised an exception"
         except snapshotter.CalledProcessError as err:
-            assert err.message == "output 25"
+            assert err.output == "output 25"
 
     def test_extra_args_are_passed_on_to_rsync(self):
         extra_args = ["-v", "--info=progress2"]
@@ -464,6 +473,7 @@ class TestRemovingOldSnapshots(object):
         self.mock_ls_snapshots_function.return_value = snapshots
 
         rsync_returns = [snapshotter.NoSpaceLeftOnDeviceError(), None]
+
         def rsync(*args, **kwargs):
             result = rsync_returns.pop(0)
             if isinstance(result, Exception):
@@ -498,6 +508,7 @@ class TestRemovingOldSnapshots(object):
             snapshotter.NoSpaceLeftOnDeviceError(),
             snapshotter.NoSpaceLeftOnDeviceError(),
             None]
+
         def rsync(*args, **kwargs):
             result = rsync_returns.pop(0)
             if isinstance(result, Exception):


### PR DESCRIPTION
ciao, i wanted to add Python 3-compatibility as it's the default python interpreter for some distributions.

first i stumpled over some tests that failed with Python 2 and fixed 'em.

the Python 3-support is a little hackish; i encountered some issues that i didn't knew yet. that may have to do with the fact that `subprocess` is involved. if you have ideas to improve it, i'd appreciate 'em.

so, two tests are still failing. eg, the odd thing is that though in `test_failed_command` the `err.output`-object is a string, but is printed as `bytes`. it also has an `encode`-method, but when is use this, the interpreter will tell me that "startswith first arg must be bytes or a tuple of bytes, not str". which is an oddness for itself. the last aspect is not included in this testing-output with debug-statements:

```
    assert err.output.startswith("rsync: --foobar: unknown option")
AssertionError: 
-------------------- >> begin captured stdout << ---------------------
type(err.output): <class 'str'>
err.output: b'rsync: --foobar: unknown option\nrsync error: syntax or usage error (code 1) at main.c(1554) [client=3.1.1]\n' 1

--------------------- >> end captured stdout << ----------------------
-------------------- >> begin captured logging << --------------------
snapshotter: INFO: rsync --foobar
--------------------- >> end captured logging << ---------------------
```

maybe my envronment is somehow fucked up, let's see travis' outcome.

and i would suggest to rename `CalledProcessError.output` to `msg` as it's Pythons canonical naming for exception-messages.